### PR TITLE
fix sendMessage function to push all devices

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function PushwooshClient(appCode, authToken, options) {
     this.apiVersion = options.apiVersion || apiVersion;
     this.useApplicationsGroup = options.useApplicationsGroup;
 
-};
+}
 
 PushwooshClient.prototype.sendMessage = function (msg, device, options, callback) {
 
@@ -59,9 +59,12 @@ PushwooshClient.prototype.sendMessage = function (msg, device, options, callback
     var defaultOptions = {
         send_date: 'now',
         ignore_user_timezone: true,
-        content: msg,
-        devices: devices
+        content: msg
     };
+
+    if(device) {
+      defaultOptions.devices = devices;
+    }
 
     var notification = extend(defaultOptions, options);
 
@@ -106,7 +109,7 @@ PushwooshClient.prototype.deleteMessage = function (msgCode, callback) {
             return callback(error);
         }
         client.parseResponse(response, body, callback);
-    })
+    });
 };
 
 PushwooshClient.prototype.registerDevice = function (options, callback) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -120,8 +120,7 @@ test('Pushwoosh send message success case with only 2 params msg and callback', 
                 notifications: [{
                     send_date: 'now',
                     ignore_user_timezone: true,
-                    content: testMsg,
-                    devices: []
+                    content: testMsg                    
                 }]
             }
         };
@@ -161,8 +160,7 @@ test('Pushwoosh send message success case for useApplicationsGroup:true with onl
                 notifications: [{
                     send_date: 'now',
                     ignore_user_timezone: true,
-                    content: testMsg,
-                    devices: []
+                    content: testMsg
                 }]
             }
         };
@@ -247,8 +245,7 @@ test('Pushwoosh send message success case with 3 params: msg, options, callback'
                 notifications: [{
                     send_date: 'now',
                     ignore_user_timezone: true,
-                    content: testMsg,
-                    devices: []
+                    content: testMsg
                 }]
             }
         };
@@ -290,8 +287,7 @@ test('Pushwoosh send message success case for useApplicationsGroup:true with 3 p
                 notifications: [{
                     send_date: 'now',
                     ignore_user_timezone: true,
-                    content: testMsg,
-                    devices: []
+                    content: testMsg
                 }]
             }
         };
@@ -564,8 +560,7 @@ test('Pushwoosh send message success case with response code 500 test 2', functi
                 notifications: [{
                     send_date: 'now',
                     ignore_user_timezone: true,
-                    content: testMsg,
-                    devices: []
+                    content: testMsg
                 }]
             }
         },
@@ -605,8 +600,7 @@ test('Pushwoosh send message success case with response code 400', function (t) 
                 notifications: [{
                     send_date: 'now',
                     ignore_user_timezone: true,
-                    content: testMsg,
-                    devices: []
+                    content: testMsg
                 }]
             }
         },


### PR DESCRIPTION
I just use pushwoosh and found your module, it great and very good document. But, I try to use simple function, sendMessage with no specific any device token 

```javascript
module.exports.push = function (req, res, next) {
  var client = new Pushwoosh(pushwooshConfig.appCode, pushwooshConfig.apiToken)

  client.sendMessage('send to all devices', function(err, results) {
     if (err) res.json({ status: 0, msg: err })
     res.json({ status: 1, msg: results })
  })
}
```

Unfortunately, I receive status code 210

```
{
  "status": 1,
  "msg": {
    "description": "Argument error",
    "detail": "Invalid devices list. \"devices\" must be an array.",
    "code": 210
  }
}
```

I try to specific device token it work well, so I decide to view your code and try little change and everything work fine. I read pushwoosh document and see some information about this issue 

```
"devices":[ "dec301908b9ba8df85e57a58e40f96f523f4c2068674f5fe2ba25cdc250a2a41"]
  // Optional. Not more than 1000 tokens in an array. If set, message will only be delivered to the devices in the list. Ignored if the applications group is used. Only lower case for iOS

```

and simple request example that

> Here’s the simple request that will just send a Hello world! push notification to **all subscribers** of the app:

```
{
    "request": {
        "application": "APPLICATION_CODE",
        "auth": "API_ACCESS_TOKEN",
        "notifications": [{
            "send_date": "now", // YYYY-MM-DD HH:mm  OR 'now'
            "ignore_user_timezone": true, // or false
            "content": "Hello world!"
        }]
    }
}
```

I didn't see devices variable in request object. Last, If I wrong, apologize for my newbie :smile: 
FYI: I just have 2 subscribers in my pushwoosh and all of them is test device 
